### PR TITLE
Added Pre and PostDraw hook for DModelPanel

### DIFF
--- a/garrysmod/lua/vgui/dmodelpanel.lua
+++ b/garrysmod/lua/vgui/dmodelpanel.lua
@@ -89,6 +89,10 @@ end
 	Name: DrawModel
 -----------------------------------------------------------]]
 function PANEL:DrawModel()
+	if hook.Run("PreDrawModelPanel", self, self.Entity) == false then 
+		return 
+	end
+	
 	local curparent = self
 	local rightx = self:GetWide()
 	local leftx = 0
@@ -107,6 +111,8 @@ function PANEL:DrawModel()
 	render.SetScissorRect( leftx, topy, rightx, bottomy, true )
 	self.Entity:DrawModel()
 	render.SetScissorRect( 0, 0, 0, 0, false )
+	
+	hook.Run("PostDrawModelPanel", self, self.Entity)
 end
 
 --[[---------------------------------------------------------


### PR DESCRIPTION
Used just like Pre/PostPlayerDraw for the DModelPanel entity. Return false on the Pre hook to stop the rendering of the model and then you can modify the entity after its drawn in the Post hook without having to override the DrawModel function. This can be used to set the material of the entity or take a pointshop-esque approach and render clientside models around the entity

I tried to name it in a similar fashion to other panel hooks like GM:OnTextEntryGetFocus.